### PR TITLE
Redraw Fix

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -131,7 +131,9 @@ CGRect unionRect(CGRect a, CGRect b) {
   {
     // Refresh according to docs
     _realMarker.tracksViewChanges = YES;
-    _realMarker.tracksViewChanges = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      _realMarker.tracksViewChanges = NO;
+    });
   }
 }
 


### PR DESCRIPTION

### What issue is this PR fixing?
fixing redraw fn on GoogleMapMarker, using dispatch_async s.t. marker gets a chance to redraw before setting trackViewChanges back to false.

### How did you test this PR?
Internal apps
