### PR TITLE
use UIManager directly from react-native

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -8,6 +8,7 @@ import {
   NativeModules,
   ColorPropType,
   findNodeHandle,
+  UIManager,
   ViewPropTypes,
   View,
 } from 'react-native';
@@ -817,7 +818,7 @@ class MapView extends React.Component {
   }
 
   _uiManagerCommand(name) {
-    return NativeModules.UIManager.getViewManagerConfig(getAirMapName(this.props.provider)).Commands[name];
+    return UIManager.getViewManagerConfig(getAirMapName(this.props.provider)).Commands[name];
   }
 
   _mapManagerCommand(name) {
@@ -831,7 +832,7 @@ class MapView extends React.Component {
   _runCommand(name, args) {
     switch (Platform.OS) {
       case 'android':
-        return NativeModules.UIManager.dispatchViewManagerCommand(
+        return UIManager.dispatchViewManagerCommand(
           this._getHandle(),
           this._uiManagerCommand(name),
           args
@@ -920,7 +921,7 @@ if (Platform.OS === 'android') {
 }
 const getAirMapComponent = provider => airMaps[provider || 'default'];
 
-const AIRMapLite = NativeModules.UIManager.getViewManagerConfig('AIRMapLite') &&
+const AIRMapLite = UIManager.getViewManagerConfig('AIRMapLite') &&
   requireNativeComponent('AIRMapLite', MapView, {
     nativeOnly: {
       onChange: true,

--- a/lib/components/decorateMapComponent.js
+++ b/lib/components/decorateMapComponent.js
@@ -3,6 +3,7 @@ import {
   requireNativeComponent,
   NativeModules,
   Platform,
+  UIManager,
 } from 'react-native';
 import {
   PROVIDER_DEFAULT,
@@ -33,12 +34,6 @@ export const createNotSupportedComponent = message => () => {
 };
 
 function getViewManagerConfig(viewManagerName) {
-  const UIManager = NativeModules.UIManager;
-  if (!UIManager.getViewManagerConfig) {
-    // RN < 0.58
-    return UIManager[viewManagerName];
-  }
-  // RN >= 0.58
   return UIManager.getViewManagerConfig(viewManagerName);
 }
 


### PR DESCRIPTION
According to discussion on internal diff 15579147, should be using UIManager module directly.

Tested by importing this branch in package.json, commenting out the workaround added as a result of the above diff, then running the internal app using this fork and confirming that maps load and do not redbox